### PR TITLE
[Create Post] 게시글 작성 화면 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.devkingdom.sodong"
-    compileSdk = 34
+    compileSdk = 35
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    // 위치 정보 권한
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    // 외부 저장소 권한
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
         android:label="sodong_app"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>앱에서 사진 라이브러리에 접근하려고 합니다.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>동네 정보를 가져오기 위해 위치 권한을 허용해 주세요</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/lib/features/create_post/data/repository/image_picker_repository.dart
+++ b/lib/features/create_post/data/repository/image_picker_repository.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ImagePickerService {
+  final ImagePicker _picker = ImagePicker();
+
+  Future<List<XFile>> pickImages() async {
+    try {
+      final pickedFiles = await _picker.pickMultiImage();
+      return pickedFiles;
+    } catch (e) {
+      throw Exception('이미지 선택 오류: $e');
+    }
+  }
+}
+
+final imagePickerRepositoryProvider = Provider<ImagePickerService>((ref) {
+  return ImagePickerService();
+});

--- a/lib/features/create_post/domain/usecase/pick_image_usecase.dart
+++ b/lib/features/create_post/domain/usecase/pick_image_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:sodong_app/features/create_post/data/repository/image_picker_repository.dart';
+
+class ImagePickerUsecase {
+  ImagePickerUsecase(this._repository);
+
+  final ImagePickerService _repository;
+
+  Future<List<XFile>> execute() async {
+    return await _repository.pickImages();
+  }
+}
+
+final pickImagesUsecaseProvider = Provider((ref) {
+  final imagePickerRepository = ref.read(imagePickerRepositoryProvider);
+  return ImagePickerUsecase(imagePickerRepository);
+});

--- a/lib/features/create_post/presentation/pages/create_post_page.dart
+++ b/lib/features/create_post/presentation/pages/create_post_page.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:sodong_app/features/create_post/presentation/view_models/create_post_view_model.dart';
+import 'package:sodong_app/features/create_post/presentation/view_models/image_picker_view_model.dart';
+import 'package:sodong_app/features/post_list/domain/models/category.dart';
+part 'widgets/category_dropdown.dart';
+part 'widgets/image_preview.dart';
+part 'widgets/title_text_field.dart';
+part 'widgets/content_text_field.dart';
+part 'widgets/image_picker_and_anonymous_row.dart';
+
+class CreatePostPage extends ConsumerStatefulWidget {
+  const CreatePostPage({super.key});
+
+  @override
+  ConsumerState<CreatePostPage> createState() => _CreatePostPageState();
+}
+
+class _CreatePostPageState extends ConsumerState<CreatePostPage> {
+  @override
+  Widget build(BuildContext context) {
+    final createPostState = ref.watch(createPostViewModelProvider);
+    final createPostViewModel = ref.read(createPostViewModelProvider.notifier);
+    final imagePickerState = ref.watch(imagePickerViewModelProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('글 쓰기'),
+        actions: [
+          TextButton(
+            onPressed: createPostState.isLoading
+                ? null
+                : () async {
+                    await createPostViewModel.submit('seoul_gangnam');
+                    // TODO : 작성한 게시물 상세 화면으로 이동
+                  },
+            child: const Text('완료'),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: createPostState.isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _CategoryDropdown(),
+                    _TitleTextField(notifier: createPostViewModel),
+                    _ContentTextField(notifier: createPostViewModel),
+                    if (imagePickerState.imageFiles != null &&
+                        imagePickerState.imageFiles!.isNotEmpty)
+                      ImagePreview(imageFiles: imagePickerState.imageFiles!),
+                    _ImagePickerAndAnonymousRow(
+                      isAnonymous: createPostState.isAnonymous,
+                      toggleAnonymous: (_) => createPostViewModel.toggleAnonymous(),
+                      onPickImages: () => ref
+                          .read(imagePickerViewModelProvider.notifier)
+                          .pickImages(),
+                    ),
+                  ],
+                )
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/create_post/presentation/pages/widgets/category_dropdown.dart
+++ b/lib/features/create_post/presentation/pages/widgets/category_dropdown.dart
@@ -1,0 +1,27 @@
+part of 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
+
+class _CategoryDropdown extends ConsumerWidget {
+  const _CategoryDropdown();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(createPostViewModelProvider);
+    final notifier = ref.read(createPostViewModelProvider.notifier);
+
+    return DropdownButton<TownLifeCategory>(
+      value: viewModel.category,
+      isExpanded: true,
+      onChanged: (newCategory) {
+        if (newCategory != null) {
+          notifier.setCategory(newCategory);
+        }
+      },
+      items: TownLifeCategory.values.map((category) {
+        return DropdownMenuItem(
+          value: category,
+          child: Text(category.text),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/features/create_post/presentation/pages/widgets/content_text_field.dart
+++ b/lib/features/create_post/presentation/pages/widgets/content_text_field.dart
@@ -1,0 +1,24 @@
+part of 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
+
+class _ContentTextField extends StatelessWidget {
+  const _ContentTextField({
+    required this.notifier,
+  });
+  
+  final CreatePostViewModel notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: TextField(
+        decoration: const InputDecoration(
+          hintText: '이야기를 들려주세요.',
+          border: InputBorder.none,
+        ),
+        maxLines: null,
+        expands: true,
+        onChanged: notifier.setContent,
+      ),
+    );
+  }
+}

--- a/lib/features/create_post/presentation/pages/widgets/image_picker_and_anonymous_row.dart
+++ b/lib/features/create_post/presentation/pages/widgets/image_picker_and_anonymous_row.dart
@@ -1,0 +1,35 @@
+part of 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
+
+class _ImagePickerAndAnonymousRow extends StatelessWidget {
+  const _ImagePickerAndAnonymousRow({
+    required this.isAnonymous,
+    required this.toggleAnonymous,
+    required this.onPickImages,
+  });
+
+  final bool isAnonymous;
+  final Function(bool?) toggleAnonymous;
+  final VoidCallback onPickImages;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        IconButton(
+          onPressed: onPickImages,
+          icon: const Icon(Icons.camera_alt_outlined),
+        ),
+        const Spacer(),
+        Row(
+          children: [
+            Checkbox(
+              value: isAnonymous,
+              onChanged: toggleAnonymous,
+            ),
+            const Text('익명'),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/lib/features/create_post/presentation/pages/widgets/image_preview.dart
+++ b/lib/features/create_post/presentation/pages/widgets/image_preview.dart
@@ -1,0 +1,29 @@
+part of 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
+
+class ImagePreview extends StatelessWidget {
+  const ImagePreview({super.key, required this.imageFiles});
+
+  final List<XFile> imageFiles;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 100,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: imageFiles.length,
+        itemBuilder: (context, index) {
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Image.file(
+              File(imageFiles[index].path),
+              width: 80,
+              height: 80,
+              fit: BoxFit.cover,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/create_post/presentation/pages/widgets/title_text_field.dart
+++ b/lib/features/create_post/presentation/pages/widgets/title_text_field.dart
@@ -1,0 +1,21 @@
+part of 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
+
+class _TitleTextField extends StatelessWidget {
+  const _TitleTextField({
+    required this.notifier,
+  });
+
+  final CreatePostViewModel notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      decoration: const InputDecoration(
+        hintText: '제목을 입력하세요.',
+        border: InputBorder.none,
+      ),
+      onChanged: notifier.setTitle,
+    );
+  }
+}
+

--- a/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
+++ b/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
@@ -37,14 +37,14 @@ class ImagePickerViewModel extends Notifier<ImagePickerState> {
     try {
       state = state.copyWith(isLoading: true);
       final imagePickerUsecase = ref.read(pickImagesUsecaseProvider);
-      final pickedFiles = await imagePickerUsecase.execute();
+      final selectedImages = await imagePickerUsecase.execute();
       state = state.copyWith(
-        imageFiles: pickedFiles,
+        imageFiles: selectedImages,
         isLoading: false,
       );
 
       final createPostNotifier = ref.read(createPostViewModelProvider.notifier);
-      for (var file in pickedFiles) {
+      for (var file in selectedImages) {
         createPostNotifier.addImage(file.path);
       }
     } catch (e) {

--- a/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
+++ b/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:sodong_app/features/create_post/domain/usecase/pick_image_usecase.dart';
+import 'package:sodong_app/features/create_post/presentation/view_models/create_post_view_model.dart';
+
+class ImagePickerState {
+  ImagePickerState({
+    this.imageFiles,
+    this.isLoading = false,
+    this.error,
+  });
+
+  final List<XFile>? imageFiles;
+  final bool isLoading;
+  final String? error;
+
+  ImagePickerState copyWith({
+    List<XFile>? imageFiles,
+    bool? isLoading,
+    String? error,
+  }) {
+    return ImagePickerState(
+      imageFiles: imageFiles ?? this.imageFiles,
+      isLoading: isLoading ?? this.isLoading,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class ImagePickerViewModel extends Notifier<ImagePickerState> {
+  @override
+  ImagePickerState build() {
+    return ImagePickerState();
+  }
+
+  Future<void> pickImages() async {
+    try {
+      state = state.copyWith(isLoading: true);
+      final imagePickerUsecase = ref.read(pickImagesUsecaseProvider);
+      final pickedFiles = await imagePickerUsecase.execute();
+      state = state.copyWith(
+        imageFiles: pickedFiles,
+        isLoading: false,
+      );
+
+      final createPostNotifier = ref.read(createPostViewModelProvider.notifier);
+      for (var file in pickedFiles) {
+        createPostNotifier.addImage(file.path);
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: '$e',
+      );
+    }
+  }
+}
+
+final imagePickerViewModelProvider =
+    NotifierProvider<ImagePickerViewModel, ImagePickerState>(() {
+  return ImagePickerViewModel();
+});

--- a/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
+++ b/lib/features/create_post/presentation/view_models/image_picker_view_model.dart
@@ -45,7 +45,13 @@ class ImagePickerViewModel extends Notifier<ImagePickerState> {
 
       final createPostNotifier = ref.read(createPostViewModelProvider.notifier);
       for (var file in selectedImages) {
-        createPostNotifier.addImage(file.path);
+        try {
+          createPostNotifier.addImage(file.path);
+        } catch (e) {
+          state = state.copyWith(
+            error: '이미지 추가 실패: ${file.path}',
+          );
+        }
       }
     } catch (e) {
       state = state.copyWith(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -129,6 +137,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   firebase_core:
     dependency: "direct main"
     description:
@@ -206,6 +246,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -296,6 +344,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   leak_tracker:
     dependency: transitive
     description:
@@ -352,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -535,4 +655,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   geolocator: ^14.0.0
   dio: ^5.8.0+1
   flutter_dotenv: ^5.1.0
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   flutter_svg: ^2.0.7
   geolocator: ^14.0.0
   dio: ^5.8.0+1
-  cloud_firestore: ^5.6.7
   flutter_dotenv: ^5.1.0
 
 dev_dependencies:


### PR DESCRIPTION
### 🚀 개요
게시글 작성 화면 구현

### 🔧 작업 내용
- image_picker 패키지 추가
- 갤러리에서 사진을 선택하고, 선택한 사진을 화면에 표시
- 갤러리에서 이미지를 선택하는 Service와 Usecase 작성
- ViewModel에서 Image 상태를 관리하는 상태 클래스를 추가하고, 상태 관리
- 게시글 작성 화면 구현
- 카테고리 선택

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/acc33958-bd26-46d0-90e3-5445ec4bb217" width="300" height="600"/>

### 💡 Issue
Closes #17 

