### PR TITLE
[Policy] 이용약관, 개인정보 처리 방침 구현

### DIFF
--- a/lib/features/auth/presentation/pages/policy/agreement_page.dart
+++ b/lib/features/auth/presentation/pages/policy/agreement_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/widgets/agreement_check_tile.dart';
+
+class AgreementPage extends StatefulWidget {
+  const AgreementPage({super.key});
+
+  @override
+  State<AgreementPage> createState() => _AgreementPageState();
+}
+
+class _AgreementPageState extends State<AgreementPage> {
+  bool agreeTerms = false;
+  bool agreePrivacy = false;
+  bool agreeLocation = false;
+
+  bool get allAgreed => agreeTerms && agreePrivacy && agreeLocation;
+  bool get canProceed => allAgreed;
+
+  void updateAll(bool value) {
+    setState(() {
+      agreeTerms = value;
+      agreePrivacy = value;
+      agreeLocation = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('약관동의')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            children: [
+              AgreementCheckTile(
+                title: '전체 동의',
+                value: allAgreed,
+                onChanged: (_) => updateAll(!allAgreed),
+                showTrailingIcon: false,
+              ),
+              const Divider(),
+              AgreementCheckTile(
+                title: '(필수) 소소한 동네 이용약관',
+                value: agreeTerms,
+                onChanged: (val) => setState(() => agreeTerms = val!),
+                onTapTrailing: () => Navigator.pushNamed(context, '/terms'),
+              ),
+              AgreementCheckTile(
+                title: '(필수) 개인정보 수집 및 이용 동의',
+                value: agreePrivacy,
+                onChanged: (val) => setState(() => agreePrivacy = val!),
+                onTapTrailing: () =>
+                    Navigator.pushNamed(context, '/privacy_policy'),
+              ),
+              AgreementCheckTile(
+                title: '(필수) 위치 정보 수집 및 이용 동의',
+                value: agreeLocation,
+                onChanged: (val) => setState(() => agreeLocation = val!),
+                onTapTrailing: () =>
+                    Navigator.pushNamed(context, '/location_policy'),
+              ),
+              const Spacer(),
+              SizedBox(
+                height: 50,
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: canProceed
+                      ? () => Navigator.pushReplacementNamed(context, '/login')
+                      : null,
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text('동의하고 계속하기'),
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/policy/location_policy_page.dart
+++ b/lib/features/auth/presentation/pages/policy/location_policy_page.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/widgets/common_widgets.dart';
+
+class LocationPolicyPage extends StatelessWidget {
+  const LocationPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('위치정보 수집 및 이용 동의')),
+      body: const SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SectionSubTitle('1. 수집하는 위치정보의 항목'),
+                SectionContent(
+                    '단말기의 GPS, Wi-Fi, 기지국 정보를 기반으로 한 현재 위치 좌표 (위도, 경도)'),
+                SizedBox(height: 16),
+                SectionSubTitle('2. 위치정보 수집·이용 목적'),
+                SectionContent('- 지역 기반 커뮤니티 콘텐츠 제공\n'
+                    '- 내 주변 게시물, 사용자, 장소 정보 제공\n'
+                    '- 동네 인증, 지역 추천 기능 등 서비스 품질 향상 목적'),
+                SizedBox(height: 16),
+                SectionSubTitle('3. 위치정보의 보유 및 이용 기간'),
+                SectionContent('- 위치정보는 수집 당시 즉시 처리되며, 별도로 저장하지 않습니다.\n'
+                    '- 단, 서비스 이용 기록과 함께 저장되는 경우는 관련 법령 또는 내부 정책에 따라 일정 기간 보관될 수 있습니다.'),
+                SizedBox(height: 16),
+                SectionSubTitle('4. 동의를 거부할 권리 및 불이익'),
+                SectionContent(
+                    '- 회원은 위치정보 수집에 동의하지 않을 수 있으며, 이 경우 지역 기반 서비스 이용에 제한이 있을 수 있습니다.\n'
+                    '  예: 내 주변 글 보기, 지역 인증, 위치 기반 알림 등'),
+                SizedBox(height: 16),
+                SectionSubTitle('5. 제3자 제공 및 위탁'),
+                SectionContent('- 위치정보는 제3자에게 제공되지 않으며, 운영 목적 외로는 사용되지 않습니다.\n'
+                    '- 단, 시스템 운영을 위한 일부 처리(예: 인프라 운영)는 위탁될 수 있습니다.'),
+                SizedBox(height: 16),
+                SectionSubTitle('6. 기타 사항'),
+                SectionContent(
+                    '- 회원은 언제든지 위치정보 제공을 중단할 수 있으며, 기기 설정 또는 서비스 내 메뉴를 통해 설정 가능합니다.\n'
+                    '- 기타 자세한 내용은 개인정보처리방침을 참고하시기 바랍니다.'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/policy/privacy_policy_page.dart
+++ b/lib/features/auth/presentation/pages/policy/privacy_policy_page.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/widgets/common_widgets.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('개인정보 처리방침')),
+      body: const SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SectionContent(
+                  '소소한 동네는 개인정보 보호법 등 관련 법령을 준수하며, '
+                  '이용자의 개인정보를 소중하게 관리하고 보호합니다. 본 개인정보처리방침은 '
+                  '이용자가 서비스를 이용함에 있어 제공하는 개인정보의 처리 목적, 수집 항목, '
+                  '보유 기간, 권리 등을 안내합니다.',
+                ),
+                SizedBox(height: 20),
+                SectionTitle('1. 개인정보의 처리 목적'),
+                SectionContent('''
+                    • 서비스 회원가입 및 본인 확인
+                    • 서비스 제공 및 기능 개선
+                    • 이용자 문의 대응 및 공지사항 전달
+                    • 부정 이용 방지 및 이용자 보호
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('2. 처리하는 개인정보 항목'),
+                SectionSubTitle('[필수 수집 항목]'),
+                SectionContent('''
+                    • 구글 계정 이메일 주소
+                    • 닉네임
+                    • 프로필 사진
+                '''),
+                SizedBox(height: 8),
+                SectionSubTitle('[선택 수집 항목]'),
+                SectionContent('''
+                    • 위치 정보: 지역 기반 기능 제공을 위해 사용되며, 이용자의 명시적 동의를 받아 수집합니다.
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('3. 개인정보의 처리 및 보유 기간'),
+                SectionContent('''
+                    • 회원 탈퇴 시 즉시 파기
+                    • 부정 이용 방지를 위해 탈퇴 후 1년간 최소 정보 보관 가능
+                    • 관계법령에 따라 일정 기간 보관이 필요한 경우 해당 법령에 따름
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('4. 개인정보의 파기 절차 및 방법'),
+                SectionContent('''
+                    • 전자적 파일: 복구 불가능한 방식으로 영구 삭제
+                    • 서면 자료: 분쇄 또는 소각
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('5. 개인정보의 제3자 제공'),
+                SectionSubTitle(
+                    '소소한 동네는 이용자의 동의 없이 개인정보를 제3자에게 제공하지 않습니다. '
+                    '단, 법령에 따라 필요한 경우는 예외로 합니다.',
+                ),
+                SizedBox(height: 20),
+                SectionTitle('6. 개인정보 처리의 위탁'),
+                SectionSubTitle(
+                    '서비스 운영을 위해 개인정보 처리 업무를 외부 업체에 위탁할 수 있으며, '
+                    '수탁자는 개인정보 보호법상 의무를 준수하도록 관리·감독합니다.',
+                ),
+                SizedBox(height: 20),
+                SectionTitle('7. 개인정보 자동 수집 장치의 설치·운영 및 거부'),
+                SectionContent('''
+                    • 쿠키 등 자동 수집 장치를 통해 이용자 접속 기록, 서비스 이용 내역을 수집할 수 있습니다.
+                    • 이용자는 웹 브라우저 설정을 통해 쿠키 저장을 거부할 수 있습니다.
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('8. 정보주체의 권리·의무 및 행사 방법'),
+                SectionSubTitle(
+                    '이용자는 언제든지 개인정보의 열람, 정정, 삭제, 처리 정지를 요청할 수 있으며, '
+                    '서비스 내 설정 또는 고객센터를 통해 권리를 행사할 수 있습니다.',
+                ),
+                SizedBox(height: 20),
+                SectionTitle('9. 14세 미만 아동의 개인정보 처리'),
+                SectionSubTitle(
+                    '소소한 동네는 14세 미만 아동의 개인정보를 수집하지 않으며, 가입 또한 제한합니다.',
+                ),
+                SizedBox(height: 20),
+                SectionTitle('10. 개인정보의 안전성 확보조치에 관한 사항'),
+                SectionContent('''
+                    • 암호화: Google 로그인을 통해 수집한 개인정보는 암호화하여 안전하게 저장합니다.
+                    • 접근 제한: 개인정보 접근 권한을 최소한의 인원에게만 부여하고, 접근 기록을 관리합니다.
+                    • 내부 교육: 개인정보를 처리하는 직원에게 정기적인 개인정보 보호 교육을 실시합니다.
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('11. 개인정보 보호책임자'),
+                SectionContent('''
+                    • 성명: 강민지
+                    • 연락처: glow3941@gmail.com
+                    • 담당 부서: 개인정보보호팀
+                '''),
+                SizedBox(height: 20),
+                SectionTitle('12. 개인정보 처리방침 변경에 관한 사항'),
+                SectionSubTitle(
+                    '본 방침은 법령, 정책 변경 또는 서비스 변경에 따라 수정될 수 있으며, '
+                    '변경 시 최소 7일 전 서비스 내 공지합니다.',
+                ),
+                SizedBox(height: 8),
+                SectionContent('''
+                    • 공고일자: 2025년 5월 21일
+                    • 시행일자: 2025년 5월 28일
+                '''),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/policy/terms_page.dart
+++ b/lib/features/auth/presentation/pages/policy/terms_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/widgets/common_widgets.dart';
+
+class TermsPage extends StatelessWidget {
+  const TermsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('이용약관')),
+      body: const SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SectionTitle('제1장 소소한 동네에 오신 걸 환영합니다'),
+                SectionSubTitle('제1조 (목적)'),
+                SectionContent(
+                    '이 약관은 "소소한 동네"(이하 \'회사\')가 제공하는 서비스의 이용조건, 회사와 회원 간의 권리 및 의무, 책임 등을 정하는 것을 목적으로 합니다.'),
+                SectionSubTitle('제2조 (약관의 적용과 변경)'),
+                SectionContent('1. 본 약관은 서비스 내 게시되며, 회원 가입과 동시에 효력이 발생합니다.\n'
+                    '2. 법령 변경 또는 서비스 개선을 위해 약관이 개정될 수 있으며, 변경사항은 시행일 7일 전부터 서비스 내 공지됩니다.\n'
+                    '3. 회원이 변경된 약관에 동의하지 않을 경우, 서비스 이용을 중단하고 탈퇴할 수 있습니다.'),
+                SectionSubTitle('제3조 (기타 준칙)'),
+                SectionContent('약관에서 다루지 않은 사항은 관계 법령 및 별도 운영정책에 따릅니다.'),
+                SizedBox(height: 20),
+                SectionTitle('제2장 계정과 가입'),
+                SectionSubTitle('제4조 (가입 조건 및 방식)'),
+                SectionContent('1. 소소한 동네는 Google 계정 로그인을 통해 간편하게 가입할 수 있습니다.\n'
+                    '2. 만 14세 이상만 회원 가입이 가능하며, 회사는 필요 시 본인 확인을 요청할 수 있습니다.'),
+                SectionSubTitle('제5조 (가입 거절 및 제한)'),
+                SectionContent('- 타인 정보를 무단 사용하거나 허위 정보를 입력한 경우\n'
+                    '- 과거 서비스 이용 중 정지 또는 탈퇴 처리된 경우\n'
+                    '- 시스템 오용 또는 서비스 방해 행위가 의심되는 경우\n'
+                    '- 기타 회사의 정책상 이용이 부적절하다고 판단되는 경우'),
+                SizedBox(height: 20),
+                SectionTitle('제3장 서비스 이용'),
+                SectionSubTitle('제6조 (제공되는 서비스)'),
+                SectionContent(
+                    '소소한 동네는 위치 기반으로 지역 주민들과 익명으로 소통할 수 있는 커뮤니티 기능을 제공합니다.\n'
+                    '게시판 글쓰기, 댓글, 공감 등의 기능을 포함하며, 서비스는 연중무휴로 운영됩니다.'),
+                SectionSubTitle('제7조 (이용자의 책임과 금지행위)'),
+                SectionContent('- 허위 정보 등록, 타인 사칭\n'
+                    '- 욕설, 혐오 표현, 차별, 음란물 등 부적절한 콘텐츠 작성\n'
+                    '- 광고 또는 상업적 목적의 홍보 활동\n'
+                    '- 서비스나 서버에 악영향을 주는 기술적 시도\n'
+                    '- 기타 법령 또는 사회질서에 위반되는 행위\n'
+                    '회사는 위반 시 사전 경고 없이 게시물 삭제, 이용 제한, 탈퇴 등의 조치를 할 수 있습니다.'),
+                SectionSubTitle('제8조 (게시물 운영)'),
+                SectionContent('1. 회원이 작성한 게시물의 권리와 책임은 본인에게 있습니다.\n'
+                    '2. 회사는 다음과 같은 경우 게시물을 삭제하거나 숨김 처리할 수 있습니다:\n'
+                    '- 법 위반 또는 타인의 권리를 침해하는 경우\n'
+                    '- 커뮤니티 운영 정책에 위배되는 경우\n'
+                    '- 허위 또는 악의적 내용을 포함하는 경우'),
+                SizedBox(height: 20),
+                SectionTitle('제4장 계정 관리와 해지'),
+                SectionSubTitle('제9조 (계정 탈퇴)'),
+                SectionContent(
+                    '회원은 언제든지 서비스 설정 메뉴를 통해 계정을 삭제할 수 있으며, 탈퇴 즉시 개인정보는 관련 법령에 따라 파기 또는 분리 보관됩니다.'),
+                SectionSubTitle('제10조 (이용 제한 및 제재)'),
+                SectionContent('- 약관 및 운영정책 반복 위반\n'
+                    '- 명백한 불법 행위나 타인 권리 침해\n'
+                    '- 커뮤니티 내 반복된 문제 유발\n'
+                    '- 기술적 공격 또는 시스템 위협 행위'),
+                SizedBox(height: 20),
+                SectionTitle('제5장 기타 사항'),
+                SectionSubTitle('제11조 (위치기반 서비스 안내)'),
+                SectionContent(
+                    '1. 소소한 동네는 회원의 위치 정보를 활용하여 지역 커뮤니티 콘텐츠를 제공합니다.\n'
+                    '2. 위치 정보 수집은 회원의 동의 하에 이루어지며, 관련 정보는 개인정보처리방침에 따릅니다.'),
+                SectionSubTitle('제12조 (개인정보 보호)'),
+                SectionContent(
+                    '회사는 회원의 개인정보를 소중히 다루며, 수집 및 이용에 대한 세부 사항은 개인정보처리방침을 통해 안내합니다.'),
+                SectionSubTitle('제13조 (서비스 책임 제한)'),
+                SectionContent(
+                    '1. 회사는 천재지변, 네트워크 장애 등 불가항력적 사유로 인한 서비스 중단에 책임지지 않습니다.\n'
+                    '2. 게시물, 댓글 등 사용자 생성 콘텐츠에 대한 법적 책임은 작성자에게 있습니다.'),
+                SectionSubTitle('제14조 (준거법 및 관할)'),
+                SectionContent(
+                    '서비스와 관련된 분쟁은 대한민국 법률을 따르며, 관할 법원은 회사 본사가 위치한 법원으로 합니다.'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/policy/widgets/agreement_check_tile.dart
+++ b/lib/features/auth/presentation/pages/policy/widgets/agreement_check_tile.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class AgreementCheckTile extends StatelessWidget {
+  const AgreementCheckTile({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.showTrailingIcon = true,
+    this.onTapTrailing,
+  });
+
+  final String title;
+  final bool value;
+  final ValueChanged<bool?> onChanged;
+  final bool showTrailingIcon;
+  final VoidCallback? onTapTrailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => onChanged(!value),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12.0),
+          child: Row(
+            children: [
+              _buildCircleCheckbox(value),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(fontSize: 14),
+                ),
+              ),
+              if (showTrailingIcon)
+                InkWell(
+                  onTap: onTapTrailing,
+                  child: const Icon(Icons.arrow_forward_ios, size: 16),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCircleCheckbox(bool value) {
+    return Container(
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: value ? Color(0xFFFF7B8E) : Colors.grey,
+          width: 2,
+        ),
+        color: value ? Color(0xFFFF7B8E) : Colors.transparent,
+      ),
+      child: value
+          ? const Icon(Icons.check, size: 14, color: Colors.white)
+          : null,
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/policy/widgets/common_widgets.dart
+++ b/lib/features/auth/presentation/pages/policy/widgets/common_widgets.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class SectionTitle extends StatelessWidget {
+  const SectionTitle(this.text, {super.key});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        fontWeight: FontWeight.bold,
+        fontSize: 18,
+      ),
+    );
+  }
+}
+
+class SectionSubTitle extends StatelessWidget {
+  const SectionSubTitle(this.text, {super.key});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12.0, bottom: 4.0),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 16,
+        ),
+      ),
+    );
+  }
+}
+
+class SectionContent extends StatelessWidget {
+  const SectionContent(this.text, {super.key});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(fontSize: 16, height: 1.5),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/profile_edit/profile_edit.dart
+++ b/lib/features/auth/presentation/pages/profile_edit/profile_edit.dart
@@ -132,6 +132,12 @@ class _ProfileEditPageState extends ConsumerState<ProfileEdit> {
                       'region': region,
                       'profileImageUrl': imageUrl,
                       'createdAt': FieldValue.serverTimestamp(),
+                      'agreements': {
+                        'terms': true,
+                        'privacy': true,
+                        'location': true,
+                        'agreedAt': FieldValue.serverTimestamp(),
+                      },
                     });
                     // 다음 페이지로 이동 또는 홈으로 이동
                     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/auth/presentation/pages/splash/splash_page.dart
+++ b/lib/features/auth/presentation/pages/splash/splash_page.dart
@@ -32,6 +32,6 @@ class _SplashPageState extends State<SplashPage> {
   void _goToLogin() async {
     await Future.delayed(const Duration(seconds: 2));
     if (!mounted) return;
-    await Navigator.pushReplacementNamed(context, '/login');
+    await Navigator.pushReplacementNamed(context, '/agreement');
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sodong_app/features/auth/presentation/pages/login/login_page.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/agreement_page.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/location_policy_page.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/privacy_policy_page.dart';
+import 'package:sodong_app/features/auth/presentation/pages/policy/terms_page.dart';
 import 'package:sodong_app/features/auth/presentation/pages/profile_edit/profile_edit.dart';
 import 'package:sodong_app/features/auth/presentation/pages/splash/splash_page.dart';
 import 'package:sodong_app/features/create_post/presentation/pages/create_post_page.dart';
@@ -28,6 +32,10 @@ class MyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const SplashPage(),
+        '/agreement': (context) => const AgreementPage(),
+        '/terms': (context) => const TermsPage(),
+        '/privacy_policy': (context) => const PrivacyPolicyPage(),
+        '/location_policy': (context) => const LocationPolicyPage(),
         '/login': (context) => const LoginPage(),
         '/signup': (context) => const ProfileEdit(),
         '/home': (context) => const PostListPage(),


### PR DESCRIPTION
### 🚀 개요
이용약관, 개인정보 처리방침, 위치 정보 수집 이용 동의 화면 구현

### 🔧 작업 내용
- 화면 구현
- 3개 항목의 체크박스를 구현하고 전체 동의 기능 구현
- 사용자의 프로필을 Firebase에 저장할 때 약관 동의 여부도 저장

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/f8d9ad4c-cac9-4a09-a7a0-504a117f0f28" width="300" height="600"/>


### 💡 Issue
Closes #40 

