### PR TITLE
[Auth] 약관 동의 후, 화면 표시 X

### DIFF
--- a/lib/features/auth/data/user_repository.dart
+++ b/lib/features/auth/data/user_repository.dart
@@ -23,7 +23,7 @@ class RemoteUserRepository implements UserRepository {
   }
 }
 
-final remoteUserRepository = Provider<UserRepository>((ref) {
+final remoteUserRepositoryProvider = Provider<UserRepository>((ref) {
   final auth = FirebaseAuth.instance;
   final firestore = FirebaseFirestore.instance;
     return RemoteUserRepository(auth: auth, firestore: firestore);

--- a/lib/features/auth/data/user_repository.dart
+++ b/lib/features/auth/data/user_repository.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sodong_app/features/auth/domain/repositories/user_repository.dart';
+
+class RemoteUserRepository implements UserRepository {
+  
+  RemoteUserRepository({
+    required this.auth,
+    required this.firestore,
+  });
+  
+  final FirebaseAuth auth;
+  final FirebaseFirestore firestore;
+
+  @override
+  User? getCurrentUser() => auth.currentUser;
+
+  @override
+  Future<bool?> isAgreementComplete(String uid) async {
+    final doc = await firestore.collection('users').doc(uid).get();
+    return doc.data()?['isAgreementComplete'] == true;
+  }
+}
+
+final remoteUserRepository = Provider<UserRepository>((ref) {
+  final auth = FirebaseAuth.instance;
+  final firestore = FirebaseFirestore.instance;
+    return RemoteUserRepository(auth: auth, firestore: firestore);
+});

--- a/lib/features/auth/domain/repositories/user_repository.dart
+++ b/lib/features/auth/domain/repositories/user_repository.dart
@@ -1,0 +1,7 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+abstract interface class UserRepository {
+  User? getCurrentUser();
+  
+  Future<bool?> isAgreementComplete(String uid);
+}

--- a/lib/features/auth/domain/usecase/check_user_status_usecase.dart
+++ b/lib/features/auth/domain/usecase/check_user_status_usecase.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sodong_app/features/auth/data/user_repository.dart';
 import 'package:sodong_app/features/auth/domain/repositories/user_repository.dart';
 
 enum UserStatus {
@@ -21,3 +23,9 @@ class CheckUserStatusUseCase {
         : UserStatus.agreementNotComplete;
   }
 }
+
+final checkUserStatusUsecaseProvider = Provider<CheckUserStatusUseCase>((ref) {
+ final repository = ref.read(remoteUserRepositoryProvider);
+ return CheckUserStatusUseCase(repository) ;
+
+});

--- a/lib/features/auth/domain/usecase/check_user_status_usecase.dart
+++ b/lib/features/auth/domain/usecase/check_user_status_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:sodong_app/features/auth/domain/repositories/user_repository.dart';
+
+enum UserStatus {
+  notLoggedIn,
+  agreementNotComplete,
+  agreementComplete,
+}
+
+class CheckUserStatusUseCase {
+  CheckUserStatusUseCase(this.repository);
+
+  final UserRepository repository;
+
+  Future<UserStatus> execute() async {
+    final user = repository.getCurrentUser();
+    if (user == null) return UserStatus.notLoggedIn;
+
+    final isComplete = await repository.isAgreementComplete(user.uid);
+    return isComplete == true
+        ? UserStatus.agreementComplete
+        : UserStatus.agreementNotComplete;
+  }
+}

--- a/lib/features/auth/presentation/pages/profile_edit/profile_edit.dart
+++ b/lib/features/auth/presentation/pages/profile_edit/profile_edit.dart
@@ -139,6 +139,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEdit> {
                             'region': region,
                             'profileImageUrl': imageUrl,
                             'createdAt': FieldValue.serverTimestamp(),
+                            'isAgreementComplete': true,
                           });
                           // 다음 페이지로 이동 또는 홈으로 이동
                           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/auth/presentation/pages/splash/splash_page.dart
+++ b/lib/features/auth/presentation/pages/splash/splash_page.dart
@@ -1,20 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sodong_app/features/auth/domain/usecase/check_user_status_usecase.dart';
 
-class SplashPage extends StatefulWidget {
+class SplashPage extends ConsumerStatefulWidget {
   const SplashPage({super.key});
 
   @override
-  State<StatefulWidget> createState() => _SplashPageState();
+  ConsumerState<SplashPage> createState() => _SplashPageState();
 }
 
-class _SplashPageState extends State<SplashPage> {
+class _SplashPageState extends ConsumerState<SplashPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFFFE6E9),
       body: Center(
-        child: Image.asset(
-          'assets/splash.png',
+        child: Image(
+          image: AssetImage('assets/splash.png'),
           width: 250,
           height: 250,
         ),
@@ -26,12 +28,30 @@ class _SplashPageState extends State<SplashPage> {
   void initState() {
     super.initState();
 
-    _goToLogin();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkUserStatus());
   }
 
-  void _goToLogin() async {
+  Future<void> _checkUserStatus() async {
     await Future.delayed(const Duration(seconds: 2));
+
+    final useCase = ref.read(checkUserStatusUsecaseProvider);
+    final status = await useCase.execute();
+
+    switch (status) {
+      case UserStatus.notLoggedIn:
+        _navigateTo('/login');
+        break;
+      case UserStatus.agreementNotComplete:
+        _navigateTo('/agreement');
+        break;
+      case UserStatus.agreementComplete:
+        _navigateTo('/home');
+        break;
+    }
+  }
+
+  void _navigateTo(String route) {
     if (!mounted) return;
-    await Navigator.pushReplacementNamed(context, '/agreement');
+    Navigator.pushReplacementNamed(context, route);
   }
 }


### PR DESCRIPTION
### 🚀 개요
약관 동의를 한 사용자면 다시 앱에 접속해도 약관 동의 화면이 보이지 않게 함

### 🔧 작업 내용
- 사용자의 프로필을 저장할 때 약관 동의 여부도 같이 저장
- Firebase의 약관 동의 여부를 검사하고 해당 화면으로 이동하는 로직 구현
- 클린 아키텍처 적용

### 💡 Issue
Closes #58 

